### PR TITLE
chore: npm plugin required to update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
+      ["@semantic-release/changelog", {
+        "changelogFile": "docs/CHANGELOG.md"
+      }],
       "@semantic-release/npm",
       [
         "@semantic-release/git",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
+    "@semantic-release/changelog": "^3.0.6",
     "@semantic-release/git": "^7.0.18",
     "@semantic-release/npm": "^5.3.4",
     "concurrently": "^4.1.2",
@@ -45,9 +46,12 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      ["@semantic-release/changelog", {
-        "changelogFile": "docs/CHANGELOG.md"
-      }],
+      [
+        "@semantic-release/changelog",
+        {
+          "changelogFile": "docs/CHANGELOG.md"
+        }
+      ],
       "@semantic-release/npm",
       [
         "@semantic-release/git",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@semantic-release/git": "^7.0.18",
+    "@semantic-release/npm": "^5.3.4",
     "concurrently": "^4.1.2",
     "husky": "^1.3.1",
     "lint-staged": "^8.2.1",
@@ -44,6 +45,7 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
       [
         "@semantic-release/git",
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,6 +110,16 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@semantic-release/changelog@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@semantic-release/changelog/-/changelog-3.0.6.tgz#9d68d68bf732cbba1034c028bb6720091f783b2a"
+  integrity sha512-9TqPL/VarLLj6WkUqbIqFiY3nwPmLuKFHy9fe/LamAW5s4MEW/ig9zW9vzYGOUVtWdErGJ1J62E3Edkamh3xaQ==
+  dependencies:
+    "@semantic-release/error" "^2.1.0"
+    aggregate-error "^3.0.0"
+    fs-extra "^8.0.0"
+    lodash "^4.17.4"
+
 "@semantic-release/commit-analyzer@^6.1.0":
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-6.3.3.tgz#885f7e46e2f0aef23a23be0904dbf18d6ece45ca"

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,7 +165,7 @@
     p-retry "^4.0.0"
     url-join "^4.0.0"
 
-"@semantic-release/npm@^5.0.5":
+"@semantic-release/npm@^5.0.5", "@semantic-release/npm@^5.3.4":
   version "5.3.4"
   resolved "https://registry.yarnpkg.com/@semantic-release/npm/-/npm-5.3.4.tgz#2998cd9455aaedf278334d4a5b56f8e0b715919d"
   integrity sha512-XjITNRA/oOpJ7BfHk/WaOHs1WniYBszTde/bwADjjk1Luacpxg87jbDQVVt/oA3Zlx+MelxACRIEuRiPC5gu8g==


### PR DESCRIPTION
Need to call the `@semantic-release/npm` plugin before the `@semantic-release/git` plugin to update and then commit the package.json file. The `private` property in the package.json is set to `true` so this won't attempt to upload to the npm registry, but will still update the package.json file. 