### PR TITLE
docs(gitbook): fix table of contents

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,5 +4,9 @@
 
 ## Development
 
-* [Project Setup](development/project-setup.md)
+* [Project Setup](docs/development/project-setup.md)
+
+## Changelog
+
+* [Changelog](docs/CHANGELOG.md) 
 


### PR DESCRIPTION
Was previously pointing to an empty Project Setup page, and the changelog wasn't being picked up. 