### PR TITLE
feat(doc-upload-api): ratelimit IPs to 100 reqs/15mins

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "dotenv": "^7.0.0",
     "express": "^4.17.1",
+    "express-rate-limit": "^5.0.0",
     "fast-csv": "^4.0.2",
     "mkdirp": "^0.5.1",
     "multer": "^1.4.2",

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path'); // eslint-disable-line global-require
 const multer = require('multer');
 const mkdirp = require('mkdirp');
+const rateLimit = require('express-rate-limit');
 
 // multer config
 const UPLOAD_PATH = 'uploads';
@@ -35,10 +36,22 @@ const upload = multer({
   }
 }).single('file');
 
+// Rate limiting config
+// Enable if you're behind a reverse proxy (Heroku, Bluemix, AWS ELB, Nginx, etc)
+// see https://expressjs.com/en/guide/behind-proxies.html
+// app.set('trust proxy', 1);
+
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100 // 100 requests per IP within 15 minute window
+});
+
 // Resolve client build directory as absolute path to avoid errors in express
 const buildPath = path.resolve(__dirname, '../client/build');
 
 const app = express();
+// only apply to requests that begin with /api/
+app.use('/api/v1/uploadData', apiLimiter);
 
 // Express only serves static assets in production
 if (process.env.NODE_ENV === 'production') {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1553,6 +1553,11 @@ expect@^24.9.0:
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
 
+express-rate-limit@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-5.0.0.tgz#9a6f4cacc388c1a1da7ba2f65db69f7395e9b04e"
+  integrity sha512-dhT57wqxfqmkOi4HM7NuT4Gd7gbUgSK2ocG27Y6lwm8lbOAw9XQfeANawGq8wLDtlGPO1ZgDj0HmKsykTxfFAg==
+
 express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"


### PR DESCRIPTION
Rate limit the `api/v1/uploadData/` endpoint by using `express-rate-limit` middleware. Limits the number of requests from a given IP to 100 for a 15 minute period (i.e, a user can only upload files at a max rate of 60 files/hour. Resolves #33 