### PR TITLE
Data name api

### DIFF
--- a/client/src/apiCalls.js
+++ b/client/src/apiCalls.js
@@ -1,4 +1,4 @@
-// This will upload the file after having read it
+// Upload the dataset
 export const upload = file => {
   const formData = new FormData();
   formData.append('file', file);
@@ -6,6 +6,26 @@ export const upload = file => {
     // Your POST endpoint
     method: 'POST',
     body: formData // This is your file object
+  })
+    .then(
+      response => response.json() // if the response is a JSON object
+    )
+    .then(
+      success => console.log(success) // Handle the success response object
+    )
+    .catch(
+      error => console.log(error) // Handle the error response object
+    );
+};
+
+// Set dataset name
+export const setName = dataName => {
+  console.log(dataName);
+  return fetch('/api/v1/setDataName', {
+    // Your POST endpoint
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: dataName })
   })
     .then(
       response => response.json() // if the response is a JSON object

--- a/client/src/apiCalls.js
+++ b/client/src/apiCalls.js
@@ -20,7 +20,6 @@ export const upload = file => {
 
 // Set dataset name
 export const setName = dataName => {
-  console.log(dataName);
   return fetch('/api/v1/setDataName', {
     // Your POST endpoint
     method: 'POST',

--- a/client/src/apiCalls.test.js
+++ b/client/src/apiCalls.test.js
@@ -1,4 +1,4 @@
-import { upload } from './apiCalls';
+import { upload, setName } from './apiCalls';
 
 describe('Test client side API calls', () => {
   beforeEach(() => {
@@ -10,6 +10,14 @@ describe('Test client side API calls', () => {
 
     //assert on the response
     upload({}).then(res => {
+      expect(res.body.success).toEqual('12345');
+    });
+  });
+
+  test('Calls /api/v1/setDataName and returns a successful response', () => {
+    fetch.mockResponseOnce(JSON.stringify({ name: '12345' }));
+    //assert on the response
+    setName({}).then(res => {
       expect(res.body.success).toEqual('12345');
     });
   });

--- a/client/src/components/FileUpload.js
+++ b/client/src/components/FileUpload.js
@@ -14,6 +14,7 @@ import Box from '@material-ui/core/Box';
 import Container from '@material-ui/core/Container';
 import UploadDiaglog from './UploadDiaglog';
 import PropTypes from 'prop-types';
+import Tooltip from '@material-ui/core/Tooltip';
 
 const useStyles = makeStyles(theme => ({
   input: {
@@ -56,10 +57,26 @@ function FileUpload({ dataName, setDataName, file, setFile }) {
 
   // State variables for UploadDialog
   const [open, setOpen] = useState(false);
+  const [nameError, setNameError] = useState('');
 
   const handleClickOpen = uploadedFile => {
     setFile(uploadedFile);
     setOpen(true);
+  };
+
+  // Only accept alphanermic strings with length <= 31
+  // Set text error accordingly
+  const validateInput = name => {
+    if (name.match(/^[a-z0-9]+$/i) && name.length <= 31) {
+      setDataName(name);
+      setNameError('');
+    } else if (name === '') {
+      setNameError('');
+    } else if (name.match(/^[a-z0-9]+$/i) === null) {
+      setNameError('Dataset name can only contain alphanumerics');
+    } else if (name.length > 31) {
+      setNameError('Dataset name can only contain 31 characters');
+    }
   };
 
   return (
@@ -90,9 +107,10 @@ function FileUpload({ dataName, setDataName, file, setFile }) {
               label="Dataset Name"
               name="dataset"
               autoComplete="dataset"
-              helperText="File must be CSV format"
+              helperText={nameError}
               autoFocus
-              onChange={event => setDataName(event.target.value)}
+              error={nameError === '' ? false : true}
+              onChange={event => validateInput(event.target.value)}
             />
             <input
               accept=".csv"
@@ -102,15 +120,18 @@ function FileUpload({ dataName, setDataName, file, setFile }) {
               onChange={event => handleClickOpen(event.target.files[0])}
             />
             <label htmlFor="contained-button-file">
-              <Button
-                fullWidth
-                variant="contained"
-                color="primary"
-                component="span"
-                className={classes.submit}
-              >
-                Upload
-              </Button>
+              <Tooltip title="File must be CSV format" placement="right">
+                <Button
+                  fullWidth
+                  variant="contained"
+                  color="primary"
+                  component="span"
+                  className={classes.submit}
+                  disabled={nameError === '' ? false : true}
+                >
+                  Upload
+                </Button>
+              </Tooltip>
             </label>
             {file && (
               <UploadDiaglog

--- a/client/src/components/FileUpload.test.js
+++ b/client/src/components/FileUpload.test.js
@@ -39,24 +39,58 @@ describe('FileUpload tests', () => {
     const mount = createMount();
     const helper = mount(<FileUpload {...props} />);
 
-    expect(helper.find(TextField).text()).toEqual(
-      'Dataset Name *​File must be CSV format'
-    );
+    expect(helper.find(TextField).text()).toEqual('Dataset Name *​');
   });
 
-  test('Updating dataset name calls setDataName callback', () => {
+  test('Updating dataset name calls setDataName callback and sets empty helper text', () => {
     wrapper
       .find(TextField)
       .at(0)
-      .simulate('change', { target: { value: 'new-name' } });
-
+      .simulate('change', { target: { value: 'newName' } });
     expect(props.setDataName).toHaveBeenCalled();
+    expect(wrapper.find(TextField).props().error).toEqual(false);
+    expect(wrapper.find(TextField).props().helperText).toEqual('');
   });
 
-  test('Updating dataset name calls setDataName callback', () => {
+  test('Updating dataset name calls setFile callback', () => {
     wrapper
       .find('input')
       .simulate('change', { target: { files: ['dummy.value'] } });
     expect(props.setFile).toHaveBeenCalled();
+  });
+
+  test('Proper helper text on name with length > 31', () => {
+    wrapper
+      .find(TextField)
+      .at(0)
+      .simulate('change', {
+        target: { value: 'abcdefghijklmnopqrstuvwxyz123456' }
+      });
+    expect(wrapper.find(TextField).props().helperText).toEqual(
+      'Dataset name can only contain 31 characters'
+    );
+    // Disable button on invalid name input
+    expect(wrapper.find(TextField).props().error).toEqual(true);
+  });
+
+  test('Proper helper text on name with non-alphanumerics', () => {
+    wrapper
+      .find(TextField)
+      .at(0)
+      .simulate('change', { target: { value: 'abcd$' } });
+    expect(wrapper.find(TextField).props().helperText).toEqual(
+      'Dataset name can only contain alphanumerics'
+    );
+    // Disable button on invalid name input
+    expect(wrapper.find(TextField).props().error).toEqual(true);
+  });
+
+  test('Proper helper text on empty input', () => {
+    wrapper
+      .find(TextField)
+      .at(0)
+      .simulate('change', { target: { value: '' } });
+    expect(wrapper.find(TextField).props().helperText).toEqual('');
+    expect(wrapper.find(TextField).props().error).toEqual(false);
   });
 });

--- a/client/src/components/UploadDiaglog.js
+++ b/client/src/components/UploadDiaglog.js
@@ -6,7 +6,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import PropTypes from 'prop-types';
-import { upload } from '../apiCalls';
+import { upload, setName } from '../apiCalls';
 
 function UploadDialog({ open, setOpen, dataName, file }) {
   //console.log(file.name)
@@ -14,8 +14,9 @@ function UploadDialog({ open, setOpen, dataName, file }) {
     setOpen(false);
   };
   const handleUpload = () => {
-    upload(file);
-    setOpen(false);
+    upload(file); // Upload the dataset
+    setName(dataName); // Set the dataset name
+    setOpen(false); // Close the dialog
   };
   return (
     <Dialog

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -4,6 +4,16 @@
     "jest": true
   },
   "rules": {
-    "import/order": "off"
+    "import/order": "off",
+    "prefer-destructuring": [
+      "error",
+      {
+        "array": true,
+        "object": false
+      },
+      {
+        "enforceForRenamedProperties": false
+      }
+    ]
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "nodemon": "^1.19.3"
   },
   "dependencies": {
+    "body-parser": "^1.19.0",
     "dotenv": "^7.0.0",
     "express": "^4.17.1",
     "express-rate-limit": "^5.0.0",

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ const rateLimit = require('express-rate-limit');
 const morgan = require('morgan');
 const rfs = require('rotating-file-stream');
 const log4js = require('log4js');
+const bodyParser = require('body-parser');
 
 // Node logger config
 log4js.configure({
@@ -83,6 +84,13 @@ app.use('/api/v1/uploadData', apiLimiter);
 // setup the logger
 app.use(morgan('combined', { stream: accessLogStream }));
 
+// body parser middleware
+app.use(bodyParser.json());
+
+// State variables
+let dataName; // dataset name
+let file; // uploaded dataset
+
 // POST route for uploading new file using upload (multer middleware)
 app.post('/api/v1/uploadData', upload, (req, res, next) => {
   logger.info('User requested /api/v1/uploadData');
@@ -93,11 +101,28 @@ app.post('/api/v1/uploadData', upload, (req, res, next) => {
       next(req.fileValidationError);
     } else {
       logger.info(`File ${req.file.originalname} uploaded successfuly.`);
+      file = req.file;
       res.status(200).send({ success: 'File successfully uploaded!' });
     }
   } catch (err) {
     logger.error('File missing from request.');
     res.status(400).send({ error: 'File required!' });
+  }
+});
+
+// POST route for setting dataset name
+app.post('/api/v1/setDataName', (req, res, next) => {
+  logger.info('User requested /api/v1/setDataName');
+  try {
+    if (req.body.name) {
+      dataName = req.body.name;
+      logger.info(`Dataset name ${dataName} received.`);
+      res.status(200).send({ success: 'Dataset name has been received.' });
+    }
+  } catch (err) {
+    logger.error(err);
+    next(err);
+    res.status(400).send({ error: 'Dataset name has not been received.' });
   }
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -102,6 +102,7 @@ app.post('/api/v1/uploadData', upload, (req, res, next) => {
     } else {
       logger.info(`File ${req.file.originalname} uploaded successfuly.`);
       file = req.file;
+      logger.info(`File object: ${file}`);
       res.status(200).send({ success: 'File successfully uploaded!' });
     }
   } catch (err) {
@@ -113,28 +114,31 @@ app.post('/api/v1/uploadData', upload, (req, res, next) => {
 // POST route for setting dataset name
 app.post('/api/v1/setDataName', (req, res, next) => {
   logger.info('User requested /api/v1/setDataName');
-  if (req.body.name) {
-    logger.info(`Dataset name ${req.body.name} received.`);
-    if (req.body.name.match(/^[a-z0-9]+$/i) && req.body.name.length <= 31) {
-      dataName = req.body.name;
-      logger.info(`Dataset name ${dataName} validation successful.`);
-      res.status(200).send({ success: 'Dataset name has been received!' });
-    } else if (req.body.name.match(/^[a-z0-9]+$/i) === null) {
-      logger.error(`Dataset name ${dataName} has non-alphanumeric characters.`);
-      res
-        .status(400)
-        .send({
+  try {
+    if (req.body.name) {
+      logger.info(`Dataset name ${req.body.name} received.`);
+      if (req.body.name.match(/^[a-z0-9]+$/i) && req.body.name.length <= 31) {
+        dataName = req.body.name;
+        logger.info(`Dataset name ${dataName} validation successful.`);
+        res.status(200).send({ success: 'Dataset name has been received!' });
+      } else if (req.body.name.match(/^[a-z0-9]+$/i) === null) {
+        logger.error(
+          `Dataset name ${dataName} has non-alphanumeric characters.`
+        );
+        res.status(400).send({
           error: 'Dataset name can only contain alphanumeric characters'
         });
-    } else if (req.body.name.length > 31) {
-      logger.error(`Dataset name ${dataName} has length greater than 31.`);
-      res
-        .status(400)
-        .send({ error: 'Dataset name can contain at-most 31 characters.' });
+      } else if (req.body.name.length > 31) {
+        logger.error(`Dataset name ${dataName} has length greater than 31.`);
+        res
+          .status(400)
+          .send({ error: 'Dataset name can contain at-most 31 characters.' });
+      }
     }
-  } else {
+  } catch (err) {
     logger.error('Dataset name not received');
     res.status(400).send({ error: 'Failed to receive dataset name.' });
+    next(err);
   }
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -112,7 +112,7 @@ app.post('/api/v1/uploadData', upload, (req, res, next) => {
 });
 
 // POST route for setting dataset name
-app.post('/api/v1/setDataName', (req, res, next) => {
+app.post('/api/v1/setDataName', (req, res) => {
   logger.info('User requested /api/v1/setDataName');
   if (req.body.name) {
     logger.info(`Dataset name ${req.body.name} received.`);
@@ -134,7 +134,6 @@ app.post('/api/v1/setDataName', (req, res, next) => {
   } else {
     logger.error('Dataset name not received');
     res.status(400).send({ error: 'Failed to receive dataset name.' });
-    next(err);
   }
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -113,16 +113,13 @@ app.post('/api/v1/uploadData', upload, (req, res, next) => {
 // POST route for setting dataset name
 app.post('/api/v1/setDataName', (req, res, next) => {
   logger.info('User requested /api/v1/setDataName');
-  try {
-    if (req.body.name) {
-      dataName = req.body.name;
-      logger.info(`Dataset name ${dataName} received.`);
-      res.status(200).send({ success: 'Dataset name has been received.' });
-    }
-  } catch (err) {
-    logger.error(err);
-    next(err);
-    res.status(400).send({ error: 'Dataset name has not been received.' });
+  if (req.body.name) {
+    dataName = req.body.name;
+    logger.info(`Dataset name ${dataName} received.`);
+    res.status(200).send({ success: 'Dataset name has been received!' });
+  } else {
+    logger.error('Dataset name not received');
+    res.status(400).send({ error: 'Failed to receive dataset name.' });
   }
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -114,28 +114,24 @@ app.post('/api/v1/uploadData', upload, (req, res, next) => {
 // POST route for setting dataset name
 app.post('/api/v1/setDataName', (req, res, next) => {
   logger.info('User requested /api/v1/setDataName');
-  try {
-    if (req.body.name) {
-      logger.info(`Dataset name ${req.body.name} received.`);
-      if (req.body.name.match(/^[a-z0-9]+$/i) && req.body.name.length <= 31) {
-        dataName = req.body.name;
-        logger.info(`Dataset name ${dataName} validation successful.`);
-        res.status(200).send({ success: 'Dataset name has been received!' });
-      } else if (req.body.name.match(/^[a-z0-9]+$/i) === null) {
-        logger.error(
-          `Dataset name ${dataName} has non-alphanumeric characters.`
-        );
-        res.status(400).send({
-          error: 'Dataset name can only contain alphanumeric characters'
-        });
-      } else if (req.body.name.length > 31) {
-        logger.error(`Dataset name ${dataName} has length greater than 31.`);
-        res
-          .status(400)
-          .send({ error: 'Dataset name can contain at-most 31 characters.' });
-      }
+  if (req.body.name) {
+    logger.info(`Dataset name ${req.body.name} received.`);
+    if (req.body.name.match(/^[a-z0-9]+$/i) && req.body.name.length <= 31) {
+      dataName = req.body.name;
+      logger.info(`Dataset name ${dataName} validation successful.`);
+      res.status(200).send({ success: 'Dataset name has been received!' });
+    } else if (req.body.name.match(/^[a-z0-9]+$/i) === null) {
+      logger.error(`Dataset name ${dataName} has non-alphanumeric characters.`);
+      res.status(400).send({
+        error: 'Dataset name can only contain alphanumeric characters.'
+      });
+    } else if (req.body.name.length > 31) {
+      logger.error(`Dataset name ${dataName} has length greater than 31.`);
+      res
+        .status(400)
+        .send({ error: 'Dataset name can contain at-most 31 characters.' });
     }
-  } catch (err) {
+  } else {
     logger.error('Dataset name not received');
     res.status(400).send({ error: 'Failed to receive dataset name.' });
     next(err);

--- a/server/server.js
+++ b/server/server.js
@@ -114,9 +114,24 @@ app.post('/api/v1/uploadData', upload, (req, res, next) => {
 app.post('/api/v1/setDataName', (req, res, next) => {
   logger.info('User requested /api/v1/setDataName');
   if (req.body.name) {
-    dataName = req.body.name;
-    logger.info(`Dataset name ${dataName} received.`);
-    res.status(200).send({ success: 'Dataset name has been received!' });
+    logger.info(`Dataset name ${req.body.name} received.`);
+    if (req.body.name.match(/^[a-z0-9]+$/i) && req.body.name.length <= 31) {
+      dataName = req.body.name;
+      logger.info(`Dataset name ${dataName} validation successful.`);
+      res.status(200).send({ success: 'Dataset name has been received!' });
+    } else if (req.body.name.match(/^[a-z0-9]+$/i) === null) {
+      logger.error(`Dataset name ${dataName} has non-alphanumeric characters.`);
+      res
+        .status(400)
+        .send({
+          error: 'Dataset name can only contain alphanumeric characters'
+        });
+    } else if (req.body.name.length > 31) {
+      logger.error(`Dataset name ${dataName} has length greater than 31.`);
+      res
+        .status(400)
+        .send({ error: 'Dataset name can contain at-most 31 characters.' });
+    }
   } else {
     logger.error('Dataset name not received');
     res.status(400).send({ error: 'Failed to receive dataset name.' });

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -48,3 +48,58 @@ describe('Upload dataset endpoint ', () => {
       });
   });
 });
+
+describe('Upload dataset name endpoint', () => {
+  const datasetName = { name: 'test' };
+  test('POST /api/v1/setDataName - recieve a new dataset name', () => {
+    return request(app)
+      .post('/api/v1/setDataName')
+      .send(datasetName)
+      .then(response => {
+        expect(response.status).toBe(200);
+        expect(response.body.error).toBeFalsy();
+        expect(response.body.success).toBe('Dataset name has been received!');
+      });
+  });
+
+  test('POST /api/v1/setDataName - 400 response with empty body', () => {
+    return request(app)
+      .post('/api/v1/setDataName')
+      .then(response => {
+        expect(response.status).toBe(400);
+        expect(response.body.success).toBeFalsy();
+        expect(response.body.error).toBe('Failed to receive dataset name.');
+      });
+  });
+
+  test('POST /api/v1/setDataName - 400 response with no name object', () => {
+    return request(app)
+      .post('/api/v1/setDataName')
+      .send({ wrongName: 'test' })
+      .then(response => {
+        expect(response.status).toBe(400);
+        expect(response.body.success).toBeFalsy();
+        expect(response.body.error).toBe('Failed to receive dataset name.');
+      });
+  });
+
+  // test('POST /api/v1/uploadData - Upload fails', () => {
+  //   return request(app)
+  //     .post('/api/v1/uploadData')
+  //     .then(response => {
+  //       expect(response.status).toBe(400);
+  //       expect(response.body.success).toBeFalsy();
+  //       expect(response.body.error).toBe('File required!');
+  //     });
+  // });
+
+  // test('POST /api/v1/uploadData - Upload fails with wrong type of file', () => {
+  //   return request(app)
+  //     .post('/api/v1/uploadData')
+  //     .attach('file', errorFilePath)
+  //     .then(response => {
+  //       expect(response.status).toBe(400);
+  //       expect(response.body.success).toBeFalsy();
+  //     });
+  // });
+});

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -72,34 +72,29 @@ describe('Upload dataset name endpoint', () => {
       });
   });
 
-  test('POST /api/v1/setDataName - 400 response with no name object', () => {
+  test('POST /api/v1/setDataName - 400 response with name containing non-alphanumerics', () => {
     return request(app)
       .post('/api/v1/setDataName')
-      .send({ wrongName: 'test' })
+      .send({ name: 'abcd$' })
       .then(response => {
         expect(response.status).toBe(400);
         expect(response.body.success).toBeFalsy();
-        expect(response.body.error).toBe('Failed to receive dataset name.');
+        expect(response.body.error).toBe(
+          'Dataset name can only contain alphanumeric characters.'
+        );
       });
   });
 
-  // test('POST /api/v1/uploadData - Upload fails', () => {
-  //   return request(app)
-  //     .post('/api/v1/uploadData')
-  //     .then(response => {
-  //       expect(response.status).toBe(400);
-  //       expect(response.body.success).toBeFalsy();
-  //       expect(response.body.error).toBe('File required!');
-  //     });
-  // });
-
-  // test('POST /api/v1/uploadData - Upload fails with wrong type of file', () => {
-  //   return request(app)
-  //     .post('/api/v1/uploadData')
-  //     .attach('file', errorFilePath)
-  //     .then(response => {
-  //       expect(response.status).toBe(400);
-  //       expect(response.body.success).toBeFalsy();
-  //     });
-  // });
+  test('POST /api/v1/setDataName - 400 response with name of length > 31 chars', () => {
+    return request(app)
+      .post('/api/v1/setDataName')
+      .send({ name: 'abcdefghijklmnopqrstuvwxyz123456' })
+      .then(response => {
+        expect(response.status).toBe(400);
+        expect(response.body.success).toBeFalsy();
+        expect(response.body.error).toBe(
+          'Dataset name can contain at-most 31 characters.'
+        );
+      });
+  });
 });

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -688,7 +688,7 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-body-parser@1.19.0:
+body-parser@1.19.0, body-parser@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==


### PR DESCRIPTION
Resolves #37. 

Adds client and server side validation that ensures the dataset name is <= 31 characters, and contains only alphanumerics -- ensures we play nice with SQL object rules. 